### PR TITLE
fix ffmpeg time string for non-english locales

### DIFF
--- a/modules/gallery/helpers/movie.php
+++ b/modules/gallery/helpers/movie.php
@@ -268,7 +268,7 @@ class movie_Core {
    * features (the last argument of mkdate above, which disables DST, is deprecated as of PHP 5.3).
    */
   static function seconds_to_hhmmssdd($seconds) {
-    return sprintf("%02d:%02d:%05.2f", floor($seconds / 3600), floor(($seconds % 3600) / 60),
+    return sprintf("%02d:%02d:%05.2F", floor($seconds / 3600), floor(($seconds % 3600) / 60),
                    floor(100 * $seconds % 6000) / 100);
   }
 


### PR DESCRIPTION
currently the use of ffmpeg failed on php environments with non-english locale, because the time formatting function used to pass time parameters to ffmpeg uses locale-dependent formatting.

This PR replaces the locale dependent `%f` with the locale independent `%F` to make it work on all systems, independent from the configured locale (cause ffmpeg expects the time in the same format always for all locales).

This requires PHP 5.0.3 at least according to the documentation: https://www.php.net/manual/en/function.sprintf.php
But that version is very old by now anyways.

