### PR TITLE
Slight config change for those using nginx and getting erratic /index.php/ file paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,40 @@ Vagrantfile
 .vagrant
 
 *.swp
+
+# Stupid macOS temporary files
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Stuff from the Nova editor
+.nova
+node_modules
+package.json
+package-lock.json
+.eslintrc.yml

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -60,6 +60,11 @@ $config["site_protocol"] = getEnv('SITE_PROTOCOL') ? getEnv('SITE_PROTOCOL') : "
 $config["index_page"] = isset($_GET["kohana_uri"]) ? "" : "index.php";
 
 /**
+ * If you're using nginx, comment the line above and uncomment the following line instead.
+ */
+// $config["index_page"]="";
+
+/**
  * Fake file extension that will be added to all generated URLs. Example: .html
  */
 $config["url_suffix"] = "";


### PR DESCRIPTION
Gallery3 users are mostly Apache-bound, but the underlying framework, Kohana 2, even though it's ancient, supports nginx as well. A working nginx configuration for Galery3 has already been developed by @jonmiller and is described on #8.

I'm not quite sure where such a configuration file ought to be placed, so that nginx users are able to find it; perhaps some day the Gallery3 wiki is available in some form again, and becomes editable once more, thus allowing the corrected nginx configuration to be placed there...

There is, however, a catch, which Jon Miller has found and fixed: the configuration file on `./application/config/config.php` needs to have:

```php
$config["index_page"]="";
```

I keep forgetting to change that :-) so I'm submitting a PR where this option is in the configuration file, but commented out by default, with a small note to potential nginx users to remove it. As said, in the future, hopefully we can place such notes and comments to an official online 'manual' for Gallery3.

The changes made to `.gitignore` are essentially to clean up the garbage generated by developing under macOS :-P

See also the discussion around the nginx configuration (and lots of personal rants...) on https://groups.google.com/g/gallery-3-users/c/7DXCw2slny8/m/UruqyKymAgAJ

_Caveat utilitor:_ this PR does not fix _everything_ for nginx installations! Like Apache installations, nginx varies a lot from system to system, and may or may not be fully configurable on hosted environments. I use Gallery3 on my own self-compiled nginx on a 'bare metal' server, which means I've got full access to every little aspect on my system, and I'm therefore able to get Gallery3 running flawlessly on _my_ environment. YMMV.

Potentially closes #8.