### PR TITLE
Remove code using compare_uri

### DIFF
--- a/modules/gallery/controllers/file_proxy.php
+++ b/modules/gallery/controllers/file_proxy.php
@@ -46,10 +46,8 @@ class File_Proxy_Controller extends Controller {
     // var_uri: gallery3/var/
     $var_uri = url::file("var/");
 
-    $compare_uri = url::file(ltrim($request_uri,'/'));
-
     // Make sure that the request is for a file inside var
-    $offset = strpos(rawurldecode($compare_uri), $var_uri);
+    $offset = strpos(rawurldecode($request_uri), $var_uri);
     if ($offset !== 0) {
       $e = new Kohana_404_Exception();
       $e->test_fail_code = 1;
@@ -57,7 +55,7 @@ class File_Proxy_Controller extends Controller {
     }
 
     // file_uri: albums/foo/bar.jpg
-    $file_uri = substr($compare_uri, strlen($var_uri));
+    $file_uri = substr($request_uri, strlen($var_uri));
 
     // type: albums
     // path: foo/bar.jpg


### PR DESCRIPTION
After installing 3.1.5 I found that I could no longer view images in galleries without guest permissions. I tracked the issue down to this change where compare_uri was constructed instead of using request_uri. When I switched back to using compare_uri as was used in 3.1.3 everything started working again.

Note that my gallery installation is not at the root of my host, but at https://host.com/gallery