### PR TITLE
Escape spaces in RewriteRule (due to CVE-2023-25690 and Apache httpd error AH10411)

### DIFF
--- a/modules/gallery/helpers/access.php
+++ b/modules/gallery/helpers/access.php
@@ -695,7 +695,7 @@ class access_Core {
         $fp = fopen("$dir/.htaccess", "w+");
         fwrite($fp, "<IfModule mod_rewrite.c>\n");
         fwrite($fp, "  RewriteEngine On\n");
-        fwrite($fp, "  RewriteRule (.*) $base_url/\$1 [L]\n");
+        fwrite($fp, "  RewriteRule (.*) $base_url/\$1 [B,L]\n");
         fwrite($fp, "</IfModule>\n");
         fwrite($fp, "<IfModule !mod_rewrite.c>\n");
         fwrite($fp, "  Order Deny,Allow\n");


### PR DESCRIPTION
Without this, on a modern version of Apache httpd (or one which has had security fixes backported like in Debian) you'll get this in your Apache httpd error log...

`[rewrite:error] [pid 29981:tid 1] [client 0.0.0.0:58698] AH10411: Rewritten query string contains control characters or spaces`

So you don't get to see any photos that have a space in the filename without this, either the main image or thumbnails.