### PR TITLE
Add support for standard proxy server variables

### DIFF
--- a/system/helpers/request.php
+++ b/system/helpers/request.php
@@ -69,6 +69,10 @@ class request_Core {
 		{
 			return $config['site_protocol'];
 		}
+        elseif ( ! empty($_SERVER['HTTP_X_FORWARDED_PROTO']) )
+        {
+            return $_SERVER['HTTP_X_FORWARDED_PROTO'];
+        }    
 		elseif ( ! empty($_SERVER['HTTPS']) AND $_SERVER['HTTPS'] === 'on')
 		{
 			return 'https';

--- a/system/helpers/url.php
+++ b/system/helpers/url.php
@@ -67,7 +67,14 @@ class url_Core {
 			if ($site_domain === '' OR $site_domain[0] === '/')
 			{
 				// Guess the server name if the domain starts with slash
-				$port = $_SERVER['SERVER_PORT'];
+                if ( ! empty($_SERVER['HTTP_X_FORWARDED_PORT']) )
+                {
+                    $port = $_SERVER['HTTP_X_FORWARDED_PORT'];
+                }
+                else
+                {
+                    $port = $_SERVER['SERVER_PORT'];
+                }
 				$port = ((($port == 80) && ($protocol == 'http')) || (($port == 443) && ($protocol == 'https')) || !$port) ? '' : ":$port";
 				$base_url = $protocol.'://'.($_SERVER['SERVER_NAME']?($_SERVER['SERVER_NAME'].$port):$_SERVER['HTTP_HOST']).$site_domain;
 			}


### PR DESCRIPTION
If x-forwarded-port or x-forwarded-proto are defined, use these headers when constructing URLs.